### PR TITLE
Allow libcrc to be used with C++ (#20)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ tstcrc.exe
 tstcrc
 bin/prc.exe
 bin/prc
+*.o

--- a/include/checksum.h
+++ b/include/checksum.h
@@ -37,6 +37,10 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /*
  * #define CRC_POLY_xxxx
  *
@@ -104,5 +108,9 @@ uint16_t		update_crc_sick(    uint16_t crc, unsigned char c, unsigned char prev_
 
 extern const uint32_t	crc_tab32[];
 extern const uint64_t	crc_tab64[];
+
+#ifdef __cplusplus
+}// Extern C
+#endif
 
 #endif  // DEF_LIBCRC_CHECKSUM_H


### PR DESCRIPTION
* Allow libcrc to be used with C++

* Ignore all objects